### PR TITLE
Fix subList offset overflow

### DIFF
--- a/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/QueryModifiers.java
+++ b/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/QueryModifiers.java
@@ -14,6 +14,7 @@
 package com.querydsl.core;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.jetbrains.annotations.Nullable;
@@ -109,6 +110,9 @@ public final class QueryModifiers implements Serializable {
   public <T> List<T> subList(List<T> list) {
     if (!list.isEmpty()) {
       var from = offset != null ? toInt(offset) : 0;
+      if (from >= list.size()) {
+        return Collections.emptyList();
+      }
       var to = limit != null ? (from + toInt(limit)) : list.size();
       return list.subList(from, Math.min(to, list.size()));
     } else {

--- a/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/QueryModifiersTest.java
+++ b/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/QueryModifiersTest.java
@@ -80,5 +80,6 @@ public class QueryModifiersTest {
     assertThat(QueryModifiers.offset(2).subList(ints)).isEqualTo(Arrays.asList(3, 4, 5));
     assertThat(QueryModifiers.limit(3).subList(ints)).isEqualTo(Arrays.asList(1, 2, 3));
     assertThat(new QueryModifiers(3L, 1L).subList(ints)).isEqualTo(Arrays.asList(2, 3, 4));
+    assertThat(QueryModifiers.offset(5).subList(ints)).isEmpty();
   }
 }


### PR DESCRIPTION
## Summary
- prevent `QueryModifiers.subList` from throwing `IndexOutOfBoundsException` when the offset is larger than the list size
- test the new behaviour

## Testing
- `./mvnw -q -pl querydsl-libraries/querydsl-core -am test` *(fails: wget failed to fetch maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68456f06a1d8833294161ccacdabdcc1